### PR TITLE
fix: correct `ERC721Metadata` ERC-165 identifier

### DIFF
--- a/src/OneOfOne.sol
+++ b/src/OneOfOne.sol
@@ -102,7 +102,7 @@ contract OneOfOne {
   function supportsInterface(bytes4 iface) public pure returns(bool) {
     return (
       iface == 0x80ac58cd     // ERC721
-      || iface == 0x150b7a02  // ERC721Metadata
+      || iface == 0x5b5e139f  // ERC721Metadata
       || iface == 0x01ffc9a7  // ERC165
     );
   }

--- a/src/test/OneOfOne.t.sol
+++ b/src/test/OneOfOne.t.sol
@@ -64,7 +64,7 @@ contract ContractTest is DSTest {
     // ERC721
     assertTrue(ooo.supportsInterface(bytes4(0x80ac58cd)));
     // ERC721Metadata
-    assertTrue(ooo.supportsInterface(bytes4(0x150b7a02)));
+    assertTrue(ooo.supportsInterface(bytes4(0x5b5e139f)));
     // ERC165
     assertTrue(ooo.supportsInterface(bytes4(0x01ffc9a7)));
     // mandated by ERC165 to be false


### PR DESCRIPTION
The `supportsInterface` function says this contract supports receiving NFTs (`onERC721Received(address,address,uint256,bytes)` signature), when it should be `0x5b5e139f` - for `ERC721Metadata`.