### PR TITLE
fix: change URI format

### DIFF
--- a/src/OneOfOne.sol
+++ b/src/OneOfOne.sol
@@ -25,7 +25,7 @@ contract OneOfOne {
 
   string public constant name = "1-of-1 Soulbound";
   string public constant symbol = "1O1S";
-  string private constant URI = "ipfs:QmPBAmzESVbx88Vtd94dmg8GCy2q4xLU3zxJfAc3puC4tW";
+  string private constant URI = "ipfs://QmPBAmzESVbx88Vtd94dmg8GCy2q4xLU3zxJfAc3puC4tW";
   /// @notice ENS namehash used to determine NFT owner
   bytes32 private immutable namehash;
   /// @notice the ENS contract, needed to find the namehash's resolver

--- a/src/test/OneOfOne.t.sol
+++ b/src/test/OneOfOne.t.sol
@@ -54,7 +54,7 @@ contract ContractTest is DSTest {
   }
 
   function testURI() public {
-    assertEq(ooo.tokenURI(0), "ipfs:QmPBAmzESVbx88Vtd94dmg8GCy2q4xLU3zxJfAc3puC4tW");
+    assertEq(ooo.tokenURI(0), "ipfs//:QmPBAmzESVbx88Vtd94dmg8GCy2q4xLU3zxJfAc3puC4tW");
   }
 
   function testResolveAddress() public {

--- a/src/test/OneOfOne.t.sol
+++ b/src/test/OneOfOne.t.sol
@@ -54,7 +54,7 @@ contract ContractTest is DSTest {
   }
 
   function testURI() public {
-    assertEq(ooo.tokenURI(0), "ipfs//:QmPBAmzESVbx88Vtd94dmg8GCy2q4xLU3zxJfAc3puC4tW");
+    assertEq(ooo.tokenURI(0), "ipfs://QmPBAmzESVbx88Vtd94dmg8GCy2q4xLU3zxJfAc3puC4tW");
   }
 
   function testResolveAddress() public {


### PR DESCRIPTION
URI format `ipfs:<hash>` will not work for applications like OpenSea.

At least change it to `ipfs://<hash>`.

Edit: Made a typo in the second commit ><
Squash before merging (if you agree to the changes)