### PR TITLE
xDeployer

### DIFF
--- a/src/OneOfOne.sol
+++ b/src/OneOfOne.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.10;
 
-import "../lib/create3/contracts/Create3.sol";
-
 /// @title 1-of-1 optimized Soulbound NFT contract
 /// @author wschwab
 /// @notice based on idea from Ross: https://gist.github.com/z0r0z/ea0b752aa9537070b0d61f8a74d5c10c
@@ -179,24 +177,24 @@ contract OneOfOne {
   }
 }
 
-// ______________________________   ___________________________________  
-// \_   ___ \______   \_   _____/  /  _  \__    ___/\_   _____/\_____  \ 
-// /    \  \/|       _/|    __)_  /  /_\  \|    |    |    __)_   _(__  < 
-// \     \___|    |   \|        \/    |    \    |    |        \ /       \
-//  \______  /____|_  /_______  /\____|__  /____|   /_______  //______  /
-//         \/       \/        \/         \/                 \/        \/ 
+//         ________                .__                             
+// ___  ___\______ \   ____ ______ |  |   ____ ___.__. ___________ 
+// \  \/  / |    |  \_/ __ \\____ \|  |  /  _ <   |  |/ __ \_  __ \
+//  >    <  |    `   \  ___/|  |_> >  |_(  <_> )___  \  ___/|  | \/
+// /__/\_ \/_______  /\___  >   __/|____/\____// ____|\___  >__|   
+//       \/        \/     \/|__|               \/         \/       
 
-contract Deployer {
+interface IxDeployer {
+  function deploy(uint256 value, bytes32 salt, bytes code) external;
+}
+
+contract DeployToxDeployer {
+  //TODO: missing how to encode constructor args
   constructor() {
-    Create3.create3(
-      keccak256(bytes("One-of-One Soulborn")), 
-      abi.encodePacked(
-        type(OneOfOne).creationCode,
-        abi.encode(
-          0x314159265dD8dbb310642f98f50C066173C1259b,
-          0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985
-        )
-      )
+    IxDeployer(0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2).deploy(
+      0,
+      keccak256("One-of-One Soulborn"),
+      type(OneOfOne).creationCode;
     );
     selfdestruct(payable(address(0)));
   }

--- a/src/OneOfOne.sol
+++ b/src/OneOfOne.sol
@@ -190,19 +190,13 @@ interface IxDeployer {
 }
 
 contract DeployToxDeployer {
+  address ens = address(0x314159265dD8dbb310642f98f50C066173C1259b);
+  bytes32 namehash = 0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985;
+  IxDeployer x = IxDeployer(0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2);
+  bytes code = abi.encodePacked(type(OneOfOne).creationCode, abi.encode(ens, namehash));
+  bytes32 salt = keccak256(abi.encode("One-of-One Soulbound"));
   constructor() {
-    address ENS = 0x314159265dD8dbb310642f98f50C066173C1259b;
-    bytes32 namehash = 0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985;
-    IxDeployer x = IxDeployer(0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2);
-    x.deploy(
-      0,
-      keccak256("One-of-One Soulborn"),
-      abi.encode(
-        type(OneOfOne).creationCode,
-        address(0x314159265dD8dbb310642f98f50C066173C1259b),
-        bytes32(0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985)
-      )
-    );
+    x.deploy(0, salt, code);
     selfdestruct(payable(address(0)));
   }
 }

--- a/src/OneOfOne.sol
+++ b/src/OneOfOne.sol
@@ -188,7 +188,16 @@ contract OneOfOne {
 
 contract Deployer {
   constructor() {
-    Create3.create3(keccak256(bytes("One-of-One Soulborn")), type(OneOfOne).creationCode);
+    Create3.create3(
+      keccak256(bytes("One-of-One Soulborn")), 
+      abi.encodePacked(
+        type(OneOfOne).creationCode,
+        abi.encode(
+          0x314159265dD8dbb310642f98f50C066173C1259b,
+          0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985
+        )
+      )
+    );
     selfdestruct(payable(address(0)));
   }
 }

--- a/src/OneOfOne.sol
+++ b/src/OneOfOne.sol
@@ -185,16 +185,23 @@ contract OneOfOne {
 //       \/        \/     \/|__|               \/         \/       
 
 interface IxDeployer {
-  function deploy(uint256 value, bytes32 salt, bytes code) external;
+  function deploy(uint256 value, bytes32 salt, bytes memory code) external;
+  function computeAddress(bytes32 salt, bytes32 codehash) external returns(address);
 }
 
 contract DeployToxDeployer {
-  //TODO: missing how to encode constructor args
   constructor() {
-    IxDeployer(0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2).deploy(
+    address ENS = 0x314159265dD8dbb310642f98f50C066173C1259b;
+    bytes32 namehash = 0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985;
+    IxDeployer x = IxDeployer(0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2);
+    x.deploy(
       0,
       keccak256("One-of-One Soulborn"),
-      type(OneOfOne).creationCode;
+      abi.encode(
+        type(OneOfOne).creationCode,
+        address(0x314159265dD8dbb310642f98f50C066173C1259b),
+        bytes32(0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985)
+      )
     );
     selfdestruct(payable(address(0)));
   }

--- a/src/test/OneOfOne.t.sol
+++ b/src/test/OneOfOne.t.sol
@@ -143,49 +143,41 @@ contract ContractTest is DSTest {
     ooo.selfDestruct();
   }
 
+  ////////////////////////////////////
+  //      deployment tests          //
+  ////////////////////////////////////
+
+  address ens = address(0x314159265dD8dbb310642f98f50C066173C1259b);
+  bytes32 namehash = 0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985;
+  IxDeployer x = IxDeployer(0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2);
+  bytes code = abi.encodePacked(type(OneOfOne).creationCode, abi.encode(ens, namehash));
+  bytes32 salt = keccak256(abi.encode("One-of-One Soulbound"));
+
   function testXDeployer() public {
-    IXDeployer x = IXDeployer(0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2);
-    emit logs(type(OneOfOne).creationCode);
-    emit log_bytes32(keccak256(bytes("One-of-One Soulborn")));
-    x.deploy(
-      0,
-      keccak256(bytes("One-of-One Soulborn")),
-      abi.encodePacked(
-        type(OneOfOne).creationCode,
-        abi.encode(
-          0x314159265dD8dbb310642f98f50C066173C1259b,
-          0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985
-        )
-      )
-    );
+    x.deploy(0, salt, code);
+
     address deployedOOO = x.computeAddress(
-      keccak256(bytes("One-of-One Soulborn")),
-      keccak256(
-        abi.encodePacked(
-          type(OneOfOne).creationCode,
-          abi.encode(
-            0x314159265dD8dbb310642f98f50C066173C1259b,
-            0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985
-          )
-        )
-      )
-    );
-    emit log_bytes32(
-      keccak256(
-        abi.encodePacked(
-          type(OneOfOne).creationCode,
-          abi.encode(
-            0x314159265dD8dbb310642f98f50C066173C1259b,
-            0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985
-          )
-        )
-      )
+      salt,
+      keccak256(code)
     );
     emit log_address(deployedOOO);
-    OneOfOne xooo = OneOfOne(deployedOOO);
+    ooo = OneOfOne(deployedOOO);
+
+    testName();
+    testSymbol();
+
+    cheats.prank(owner);
+    // want to make sure the next test deploys
+    // so we destroy the contract first
+    ooo.selfDestruct();
   }
 
   function testDeployer() public {
     DeployToxDeployer d = new DeployToxDeployer();
+    address deployedOOO = x.computeAddress(salt, keccak256(code));
+    ooo = OneOfOne(deployedOOO);
+
+    testName();
+    testSymbol();
   }
 }

--- a/src/test/OneOfOne.t.sol
+++ b/src/test/OneOfOne.t.sol
@@ -16,6 +16,11 @@ interface CheatCodes {
   ) external;
 }
 
+interface IXDeployer {
+  function deploy(uint256 value, bytes32 salt, bytes memory code) external;
+  function computeAddress(bytes32 salt, bytes32 codeHash) external returns(address);
+}
+
 contract ContractTest is DSTest {
   OneOfOne ooo;
   CheatCodes cheats = CheatCodes(HEVM_ADDRESS);
@@ -136,5 +141,48 @@ contract ContractTest is DSTest {
   function testSelfDestructByNonOwner() public {
     cheats.expectRevert(OneOfOne.Unauthorized.selector);
     ooo.selfDestruct();
+  }
+
+  function testCreate3() public {
+    Deployer d = new Deployer();
+  }
+
+  function testXDeployer() public {
+    IXDeployer x = IXDeployer(0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2);
+    emit logs(type(OneOfOne).creationCode);
+    emit log_bytes32(keccak256(bytes("One-of-One Soulborn")));
+    x.deploy(
+      0,
+      keccak256(bytes("One-of-One Soulborn")),
+      abi.encodePacked(
+        type(OneOfOne).creationCode,
+        abi.encode(
+          0x314159265dD8dbb310642f98f50C066173C1259b,
+          0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985
+        )
+      )
+    );
+    address deployedOOO = x.computeAddress(
+      keccak256(bytes("One-of-One Soulborn")),
+      keccak256(
+        abi.encodePacked(
+          type(OneOfOne).creationCode,
+          abi.encode(
+            0x314159265dD8dbb310642f98f50C066173C1259b,
+            0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985
+          )
+        )
+      )
+    );
+    emit log_bytes32(keccak256(
+        abi.encodePacked(
+          type(OneOfOne).creationCode,
+          abi.encode(
+            0x314159265dD8dbb310642f98f50C066173C1259b,
+            0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985
+          )
+        )
+      ));
+    OneOfOne xooo = OneOfOne(deployedOOO);
   }
 }

--- a/src/test/OneOfOne.t.sol
+++ b/src/test/OneOfOne.t.sol
@@ -143,10 +143,6 @@ contract ContractTest is DSTest {
     ooo.selfDestruct();
   }
 
-  function testCreate3() public {
-    Deployer d = new Deployer();
-  }
-
   function testXDeployer() public {
     IXDeployer x = IXDeployer(0x13b0D85CcB8bf860b6b79AF3029fCA081AE9beF2);
     emit logs(type(OneOfOne).creationCode);
@@ -184,5 +180,9 @@ contract ContractTest is DSTest {
         )
       ));
     OneOfOne xooo = OneOfOne(deployedOOO);
+  }
+
+  function testDeployer() public {
+    DeployToxDeployer d = new DeployToxDeployer();
   }
 }

--- a/src/test/OneOfOne.t.sol
+++ b/src/test/OneOfOne.t.sol
@@ -170,7 +170,8 @@ contract ContractTest is DSTest {
         )
       )
     );
-    emit log_bytes32(keccak256(
+    emit log_bytes32(
+      keccak256(
         abi.encodePacked(
           type(OneOfOne).creationCode,
           abi.encode(
@@ -178,7 +179,9 @@ contract ContractTest is DSTest {
             0xb77f95208cec8af4dec158916be641e4f07614e1fa019686396b7a6da91aa985
           )
         )
-      ));
+      )
+    );
+    emit log_address(deployedOOO);
     OneOfOne xooo = OneOfOne(deployedOOO);
   }
 


### PR DESCRIPTION
This PR switches the deployer from CREATE3 to [xDeployer](https://github.com/pcaversaccio/xdeployer). Thanks to @pcaversaccio for figuring out why testnet deployments had not been working - while embarrassing, it was simply because ENS isn't deployed to them.

There are also tests for testing using xDeployer, and for specifically using the deployer contract in `OneOfOne.sol` for deployments using xDeployer.